### PR TITLE
Delete backdrop when using GUI to delete movie

### DIFF
--- a/MovingPictures/MainUI/MovingPicturesGUI.cs
+++ b/MovingPictures/MainUI/MovingPicturesGUI.cs
@@ -1765,6 +1765,13 @@ namespace MediaPortal.Plugins.MovingPictures.MainUI {
                 bool deleteSuccesful = movie.DeleteFiles();
 
                 if (deleteSuccesful) {
+                    // delete backdrop
+                    string backdropFullPath = movie.BackdropFullPath.Trim();
+                    if (!string.IsNullOrEmpty(backdropFullPath))
+                    {
+                        try { System.IO.File.Delete(backdropFullPath); } catch { }
+                    }
+
                     if (browser.CurrentView == BrowserViewMode.DETAILS)
                         // return to the facade screen
                         browser.CurrentView = browser.PreviousView;


### PR DESCRIPTION
Delete backdrop when using GUI to delete movie.
This helps prevent fanart from getting displayed for movies that are no longer present.